### PR TITLE
Housekeeping

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = coverage,Gemfile.lock,sublime*
+; ignore-words-list = softwares

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['2.7', '3.0', '3.1', '3.2', head] }
+      matrix: { ruby: ['3.1', '3.2', '3.3'] }
 
     steps:
     - name: Check out code

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,21 @@
+require:
+  - rubocop-performance
+  - rubocop-rspec
+
+inherit_gem:
+  rentacop:
+    - rentacop.yml
+    - rspec.yml
+
+AllCops:
+  TargetRubyVersion: 3.1
+  Exclude:
+    - dev/**/*
+
+Lint/EmptyBlock:
+  Exclude:
+    - server.rb
+
+Metrics/BlockLength:
+  Exclude:
+    - server.rb

--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,14 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "sinatra"
-gem "sinatra-contrib"
-gem "thin"
+gem 'sinatra', '>= 4'
+gem 'sinatra-contrib'
+gem 'thin'
 
 group :development do
+  gem 'debug'
   gem 'rack-test'
   gem 'rspec'
   gem 'rspec_approvals'
-  gem "byebug"
-  gem "simplecov"
+  gem 'simplecov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'sinatra', '>= 4'
 gem 'sinatra-contrib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,50 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (11.1.3)
+    base64 (0.2.0)
     colsole (1.0.0)
     daemons (1.4.1)
-    diff-lcs (1.5.0)
+    debug (1.9.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    diff-lcs (1.5.1)
     diffy (3.4.2)
     docile (1.4.0)
     eventmachine (1.2.7)
+    io-console (0.7.2)
+    irb (1.11.2)
+      rdoc
+      reline (>= 0.4.2)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
-    rack (2.2.6.4)
-    rack-protection (3.0.5)
-      rack
+    psych (5.1.2)
+      stringio
+    rack (3.0.9.1)
+    rack-protection (4.0.0)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.1)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.2)
+    rdoc (6.6.2)
+      psych (>= 4.0.0)
+    reline (0.4.3)
+      io-console (~> 0.5)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.4)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
     rspec_approvals (0.9.3)
       colsole (>= 0.8.1, < 2)
       diffy (~> 3.4)
@@ -41,37 +57,39 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sinatra (3.0.5)
+    sinatra (4.0.0)
       mustermann (~> 3.0)
-      rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.0.5)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.0.0)
+      rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    sinatra-contrib (3.0.5)
-      multi_json
+    sinatra-contrib (4.0.0)
+      multi_json (>= 0.0.2)
       mustermann (~> 3.0)
-      rack-protection (= 3.0.5)
-      sinatra (= 3.0.5)
+      rack-protection (= 4.0.0)
+      sinatra (= 4.0.0)
       tilt (~> 2.0)
     string-similarity (2.1.0)
+    stringio (3.1.0)
     strings-ansi (0.2.0)
-    thin (1.8.1)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
-    tilt (2.1.0)
+    thin (1.6.2)
+      daemons (>= 1.0.9)
+      eventmachine (>= 1.0.0)
+      rack (>= 1.0.0)
+    tilt (2.3.0)
 
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  byebug
+  debug
   rack-test
   rspec
   rspec_approvals
   simplecov
-  sinatra
+  sinatra (>= 4)
   sinatra-contrib
   thin
 
 BUNDLED WITH
-   2.4.8
+   2.5.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   bash:
     build: .

--- a/server.rb
+++ b/server.rb
@@ -1,6 +1,6 @@
 require 'sinatra'
-require "sinatra/streaming"
-require 'byebug' if ENV['BYEBUG']
+require 'sinatra/streaming'
+require 'debug' if ENV['DEBUGGER']
 
 helpers do
   def stream_command(command)
@@ -10,6 +10,7 @@ helpers do
       IO.popen command do |io|
         io.each do |line|
           break if out.closed?
+
           puts line unless ENV['QUIET_SERVER']
           out << line
         end
@@ -32,7 +33,7 @@ get '/help' do
 end
 
 get '/raw/:options' do
-  options = params[:options].gsub '+', ' '
+  options = params[:options].tr '+', ' '
   stream_command "stress #{options}"
 end
 
@@ -53,9 +54,9 @@ get '/stress' do
   hdd_bytes = params[:'hdd-bytes'] || params[:hdd_bytes]
 
   options = []
-  options.push "--verbose" if verbose
-  options.push "--quiet"   if quiet
-  options.push "--dry-run" if dry_run
+  options.push '--verbose' if verbose
+  options.push '--quiet'   if quiet
+  options.push '--dry-run' if dry_run
   options.push "--timeout #{timeout}" if timeout
   options.push "--backoff #{backoff}" if backoff
   options.push "--cpu #{cpu}" if cpu
@@ -64,11 +65,10 @@ get '/stress' do
   options.push "--vm-bytes #{vm_bytes}" if vm_bytes
   options.push "--vm-stride #{vm_stride}" if vm_stride
   options.push "--vm-hang #{vm_hang}" if vm_hang
-  options.push "--vm-keep" if vm_keep
+  options.push '--vm-keep' if vm_keep
   options.push "--hdd #{hdd}" if hdd
   options.push "--hdd-bytes #{hdd}" if hdd_bytes
 
   options = options.join ' '
   stream_command "stress #{options}"
 end
-

--- a/spec/routes/help_spec.rb
+++ b/spec/routes/help_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'GET /help' do
-  it "works" do
+  it 'is successful' do
     get '/help'
     expect(last_response).to be_ok
     expect(last_response.body).to match_approval('help')

--- a/spec/routes/raw_spec.rb
+++ b/spec/routes/raw_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe 'GET /raw/:options' do
-  it "works" do
+  it 'is successful' do
     get '/raw/--help'
     expect(last_response).to be_ok
     expect(last_response.body).to match_approval('help')
   end
 
-  it "runs" do
+  it 'runs' do
     get '/raw/--dry-run+-c+1'
     expect(last_response).to be_ok
     expect(last_response.body).to match_approval('raw').except(/\d{3,6}/).diff(3)

--- a/spec/routes/root_spec.rb
+++ b/spec/routes/root_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'GET /' do
-  it "works" do
+  it 'is successful' do
     get '/'
     expect(last_response).to be_ok
   end

--- a/spec/routes/stress_spec.rb
+++ b/spec/routes/stress_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'GET /stress' do
-  it "works" do
+  it 'is successful' do
     get '/stress?dry_run=1&c=2&verbose=1&t=10&m=2&d=2&vm-bytes=128M&vm_keep=1'
     expect(last_response).to be_ok
     expect(last_response.body).to match_approval('stress').except(/\d{3,6}/).diff(3)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,11 +17,10 @@ require File.expand_path '../server', __dir__
 # Bootstrap Sinatra testing with rspec
 module RSpecMixin
   include Rack::Test::Methods
-  def app() Sinatra::Application end
+  def app = Sinatra::Application
 end
 
 # Configure RSpec
 RSpec.configure do |config|
   config.include RSpecMixin
 end
-


### PR DESCRIPTION
- Add codespell
- Drop support for Ruby <= 3.0
- Lint with Rubocop
- Update dependencies
- Replace `byebug` with `debug`
